### PR TITLE
Fix compatibilty with LuaJIT 2.1

### DIFF
--- a/src/lxplib.c
+++ b/src/lxplib.c
@@ -586,7 +586,7 @@ static void set_info (lua_State *L) {
 }
 
 
-#if !defined LUA_VERSION_NUM || LUA_VERSION_NUM==501
+#if !defined(luaL_newlibtable) && (!defined LUA_VERSION_NUM || LUA_VERSION_NUM==501)
 /*
 ** Adapted from Lua 5.2.0
 */


### PR DESCRIPTION
LuaJIT 2.1 defines `luaL_setfuncs` which broke the build. I adapted the fix from https://github.com/openresty/lua-cjson/commit/55d22ef3bc5f512a9dadd84fd85895824dad73d9, and was able to successfully build.

Also see https://github.com/LuaJIT/LuaJIT/issues/325 for some discussion about this issue.